### PR TITLE
BasecampへのリンクのテキストをプロジェクトのIDにする

### DIFF
--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -30,6 +30,7 @@
     %tr
       %th プロジェクト名
       %th 更新日時
+      %th Basecamp
       %th
     - for project in @projects
       - if @person_projects.member?(project.id)

--- a/app/views/projects/_of_person.html.haml
+++ b/app/views/projects/_of_person.html.haml
@@ -1,6 +1,7 @@
 %tr.project{ data: {"project-recently-updated": project.attributes["updated_at"].try {|date| date > 1.months.ago }.to_s } }
   %th.name= link_to project.name, project_url(project.id)
   %td.updated_at= l Time.parse(project.attributes["updated_at"]), format: :long
+  %td.url= link_to project.id, project.app_url, target: "_blank"
   %td.access
     = label_tag nil, nil, "data-disabled": !manageable_person?(@person) do
       = check_box_tag "access", "1", have_access, "data-person-id": @person.id, "data-project-id": project.id, disabled: !manageable_person?(@person)

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -12,4 +12,4 @@
         %th.name= link_to project.name, project_url(project.id)
         %td.created_at= l Time.parse(project.attributes["created_at"]), format: :long
         %td.updated_at= l Time.parse(project.attributes["updated_at"]), format: :long
-        %td.url= link_to "Show", project.app_url, target: "_blank"
+        %td.url= link_to project.id, project.app_url, target: "_blank"


### PR DESCRIPTION
#7 の問題を少しでも改善するためのPR。
リンクテキストを、プロジェクトのIDにすることでページ内検索しやすくしてみました。

個人ページ
![camp-2](https://cloud.githubusercontent.com/assets/656742/8371272/2235ef46-1c10-11e5-9fa4-af5ed79f1bdc.jpg)

プロジェクト一覧
![camp-1](https://cloud.githubusercontent.com/assets/656742/8371276/2c6faf38-1c10-11e5-8cf3-f93ad2f44907.jpg)
